### PR TITLE
Auto restart api using nodemon in container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD [ "npm", "start" ]
+CMD [ "npm", "run", "dev" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,9 +10,11 @@ services:
     ports:
       - 27017:27017
 
-  agendaapi:
+  api:
     build: ./
     container_name: agenda-api
+    volumes:
+      - ./:/app
     ports:
       - 5000:5000
     depends_on:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node lib/index.js",
-    "dev": "nodemon lib/index.js",
+    "dev": "nodemon -L lib/index.js",
     "test": "test.js"
   },
   "repository": {


### PR DESCRIPTION
### Summary
There were some issues with networking using the db as a docker container and the api running on the local os. We would have to change source code to fix it so I tried to figure out how to get the api to restart while in a container when changes are in the ide. This can be done by using a [docker volume](https://docs.docker.com/storage/volumes/). It essentially links the file system of the container to a location on the host computer. Of course things were not that simple. Nodemons default file change resolution algorithm doesn't detect changes in a volume because it does not explore symlinks (the way that we link the container to our files with a volume). Thankfully there was an option to force it to traverse the symlink with `nodemon -L`.

### Why
We can now just use `docker-compose build` and `docker-compose up` and forget about it. The api will restart every time we make a change 🔥 🥳 🎈 .

### Changes
- Add docker volume to api container connected to our code
- Change `dev` script to use `nodemon -L` in `package.json`
- Change dockerfile to run `dev` instead of `start`